### PR TITLE
更新文件路径而不重新生成封面

### DIFF
--- a/fileLoader/folder.js
+++ b/fileLoader/folder.js
@@ -82,7 +82,7 @@ const deleteImageFromFolder = async (filename, folderpath) => {
 }
 
 
-const isTheSameFile = async (filepath, type, Manga) => {
+const findSameFile = async (filepath, type, Manga) => {
   let fileStat, bundleSize, mtime
   if(type === 'folder') {
     fileStat = await stat(filepath)
@@ -98,7 +98,7 @@ const isTheSameFile = async (filepath, type, Manga) => {
     where: {
       filepath: { [Op.like]: `%${filename}` },
       bundleSize: bundleSize,
-      mtime: mtime.toISOString() // mtime is text type in the database
+      mtime: mtime.toJSON() // mtime is text type in the database
     },
     raw: true
   });
@@ -114,5 +114,5 @@ module.exports = {
   solveBookTypeFolder,
   getImageListFromFolder,
   deleteImageFromFolder,
-  isTheSameFile
+  findSameFile
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const { prepareMangaModel, prepareMetadataModel } = require('./modules/database'
 const { prepareTemplate } = require('./modules/prepare_menu.js')
 const { getBookFilelist, geneCover, getImageListByBook, deleteImageFromBook } = require('./fileLoader/index.js')
 const { STORE_PATH, TEMP_PATH, COVER_PATH, VIEWER_PATH, prepareSetting, prepareCollectionList, preparePath } = require('./modules/init_folder_setting.js')
-const { isTheSameFile } = require('./fileLoader/folder.js');
+const { findSameFile } = require('./fileLoader/folder.js');
 
 preparePath()
 let setting = prepareSetting()
@@ -260,13 +260,13 @@ ipcMain.handle('load-book-list', async (event, scan) => {
           * check whether the file is the relocated only
           * return the existing data if and only if there is one match
           * */
-          const existingManga = await isTheSameFile(filepath,type, Manga)
+          const existingManga = await findSameFile(filepath,type, Manga)
           if (existingManga) {
             // the file is relocated only, so no need to regenerate the cover
             foundPrevBook = bookList.find(b => b.id === existingManga.id)
             // this is necessary otherwise it will be deleted in the next step
             foundPrevBook.exist = true
-            foundPrevBook.coverPath = existingManga.coverPath
+            foundPrevBook.coverPath = path.join(COVER_PATH, path.basename(existingManga.coverPath))
             // update the Mangas table in database.sqlite
             await Manga.update(
                 {filepath: filepath, exist: true},


### PR DESCRIPTION
# 修改
假设用户已经扫描了文件库 (Manual Scan)后移动了文件位置，比如放在不同的文件夹，重新点Manual Scan 后，新功能直接在database.sqlite 更新filepath， 并且跳过 `geneCover`

# Why?
最近批量修改了文件夹的命名规则，结果全部的cover都更新了一次 😵‍💫 

# 缺陷
新方法用文件名来寻找在`database.sqlite`对应的数据。如果有重复但位置不同的文件，这个方法会把重复的文件都指向单一个文件位置

# 不同想法
当用户修改了 `Library Folder`， 会删除`database.sqlite`的数据。是否要保留原有数据一段时间？ 比如只删除 exist=false & createdAt < current time - 1 week 。 

比如我改了主目录，但里面的位置都没有变化，软件不应该重新更新一次。 