### PR TITLE
filter: 增加non-tag only 和 tag-failed only 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,8 @@
             <el-option :label="$t('m.bookmarkOnly')" value="mark"></el-option>
             <el-option :label="$t('m.collectionOnly')" value="collection"></el-option>
             <el-option :label="$t('m.hiddenOnly')" value="hidden"></el-option>
+            <el-option :label="$t('m.nonTagOnly')" value="nontag"></el-option>
+            <el-option :label="$t('m.tagFailedOnly')" value="tagfail"></el-option>
           </el-option-group>
           <el-option-group :label="$t('m.sort')">
             <el-option :label="$t('m.shuffle')" value="shuffle"></el-option>
@@ -725,6 +727,14 @@ export default defineComponent({
           this.displayBookList = _.filter(this.bookList, 'hiddenBook')
           this.chunkList()
           break
+        case 'nontag':
+          this.displayBookList = _.filter(this.bookList, this.isNonTag)
+          this.chunkList()
+          break
+        case 'tagfail':
+          this.displayBookList = _.filter(this.bookList, this.isTagFailed)
+          this.chunkList()
+          break
         case 'shuffle':
           this.displayBookList = _.shuffle(bookList)
           this.chunkList()
@@ -1212,6 +1222,12 @@ export default defineComponent({
         this.comments = []
         if (this.setting.showComment) this.getComments(selectBook.url)
       }, 500)
+    },
+    isNonTag(book){
+      return book.status === 'non-tag'
+    },
+    isTagFailed(book){
+      return book.status === 'tag-failed'
     },
   }
 })

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -10,6 +10,8 @@
     "bookmarkOnly": "Bookmark Only",
     "collectionOnly": "Collection Only",
     "hiddenOnly": "Hidden Only",
+    "nonTagOnly": "Non-Tag Only",
+    "tagFailedOnly": "Tag-Failed Only",
     "addTimeAscend": "AddTime Ascend",
     "addTimeDescend": "AddTime Descend",
     "postTimeAscend": "PostTime Ascend",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -10,6 +10,8 @@
     "bookmarkOnly": "仅收藏",
     "collectionOnly": "仅合集",
     "hiddenOnly": "仅隐藏",
+    "nonTagOnly": "仅无标签",
+    "tagFailedOnly": "仅标签失败",
     "addTimeAscend": "添加时间正序",
     "addTimeDescend": "添加时间倒序",
     "postTimeAscend": "上传时间正序",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -10,6 +10,8 @@
     "bookmarkOnly": "僅收藏",
     "collectionOnly": "僅合集",
     "hiddenOnly": "僅隱藏",
+    "nonTagOnly": "僅無標籤",
+    "tagFailedOnly": "僅標籤失敗",
     "addTimeAscend": "新增時間升序",
     "addTimeDescend": "新增時間降序",
     "postTimeAscend": "上傳時間升序",


### PR DESCRIPTION
## 改变
在筛选/排序 （filter/sort）下增加 non-tag only 和 tag-failed only 的选项

## Why？ 
我经常需要搜 "non-tag"$ 和 "tag-failed"$来手动添加tags， 多个filter会方便很多