### PR TITLE
feat: Implement natural file sorting using Windows StrCmpLogicalW

### DIFF
--- a/fileLoader/archive.js
+++ b/fileLoader/archive.js
@@ -4,7 +4,7 @@ const { globSync } = require('glob')
 const { nanoid } = require('nanoid')
 const { spawn } = require('child_process')
 const _ = require('lodash')
-const { getRootPath } = require('../modules/utils.js')
+const { getRootPath, naturalSort } = require('../modules/utils.js')
 
 const _7z = path.join(getRootPath(), 'resources/extraResources/7z.exe')
 
@@ -28,7 +28,7 @@ const solveBookTypeArchive = async (filepath, TEMP_PATH, COVER_PATH) => {
     return match ? match[0] : ''
   })
   let imageList = _.filter(pathlist, p => ['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif'].includes(path.extname(p).toLowerCase()))
-  imageList = imageList.sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: 'base'}))
+  imageList = await naturalSort(imageList)
 
   let targetFile
   let targetFilePath
@@ -67,7 +67,7 @@ const getImageListFromArchive = async (filepath, VIEWER_PATH) => {
     nocase: true
   })
   list = _.filter(list, s => !_.includes(s, '__MACOSX'))
-  list = list.sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: 'base'}))
+  list = await naturalSort(list)
   return list.map(f => ({
     relativePath: f,
     absolutePath: path.join(tempFolder, f)

--- a/fileLoader/folder.js
+++ b/fileLoader/folder.js
@@ -5,6 +5,7 @@ const { readdir, stat } = require('fs/promises')
 const { shell } = require('electron')
 const fs = require('fs')
 const { Op } = require("sequelize")
+const { naturalSort } = require('../modules/utils.js')
 
 const dirSize = async dir => {
   const files = await readdir(dir, { withFileTypes: true })
@@ -40,7 +41,7 @@ const solveBookTypeFolder = async (folderpath, TEMP_PATH, COVER_PATH) => {
     cwd: folderpath,
     nocase: true
   })
-  list = list.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })).map(f => path.join(folderpath, f))
+  list = (await naturalSort(list)).map(f => path.join(folderpath, f))
   let targetFilePath
   if (list.length > 8) {
     targetFilePath = list[7]
@@ -59,7 +60,7 @@ const getImageListFromFolder = async (folderpath, VIEWER_PATH) => {
     cwd: folderpath,
     nocase: true
   })
-  list = list.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }))
+  list = await naturalSort(list)
   return list.map(f => ({
     relativePath: f,
     absolutePath: path.join(folderpath, f)

--- a/fileLoader/zip.js
+++ b/fileLoader/zip.js
@@ -4,6 +4,7 @@ const { globSync } = require('glob')
 const AdmZip = require('adm-zip')
 const { nanoid } = require('nanoid')
 const _ = require('lodash')
+const { naturalSort } = require('../modules/utils.js')
 
 const getZipFilelist = async (libraryPath) => {
   const list = globSync('**/*.@(zip|cbz)', {
@@ -25,7 +26,7 @@ const solveBookTypeZip = async (filepath, TEMP_PATH, COVER_PATH) => {
   }
   const fileList = zipFileList.map(zFile => zFile.entryName)
   let imageList = _.filter(fileList, filepath => _.includes(['.jpg', ',jpeg', '.png', '.webp', '.avif', '.gif'], path.extname(filepath).toLowerCase()))
-  imageList = imageList.sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: 'base'}))
+  imageList = await naturalSort(imageList)
 
   let targetFile
   let targetFilePath
@@ -66,7 +67,7 @@ const getImageListFromZip = async (filepath, VIEWER_PATH) => {
     nocase: true
   })
   list = _.filter(list, s => !_.includes(s, '__MACOSX'))
-  list = list.sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: 'base'}))
+  list = await naturalSort(list)
   return list.map(f => ({
     relativePath: f,
     absolutePath: path.join(tempFolder, f)

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,4 +1,4 @@
-const { app } = require('electron')
+const { app, ipcRenderer } = require('electron')
 const path = require('node:path')
 
 const getRootPath = () => {
@@ -9,6 +9,15 @@ const getRootPath = () => {
   }
 }
 
+async function naturalSort(files) {
+  try {
+    return await ipcRenderer.invoke('natural-sort', files)
+  } catch (error) {
+    return files.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }))
+  }
+}
+
 module.exports = {
-  getRootPath
+  getRootPath,
+  naturalSort
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express": "^4.19.2",
     "glob": "^10.3.3",
     "https-proxy-agent": "^7.0.2",
+    "koffi": "^2.14.1",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.2",
     "node-fetch": "^2.7.0",


### PR DESCRIPTION
- Add koffi integration for accessing Windows shell API
- Replace localeCompare with StrCmpLogicalW for natural sorting
- Implement IPC communication between main and renderer processes
- Update image list sorting in folder, zip, and archive loaders
- Add fallback to default sorting if koffi initialization fails
- Add koffi dependency to package.json

This change improves file sorting to handle numeric sequences correctly, e.g., page2.jpg now comes before page10.jpg.

所有漫画文件（文件夹、ZIP、RAR、7Z）的图片列表都改为使用 Windows 的 StrCmpLogicalW 函数进行排序，排序后应该和 Windows 的资源管理器顺序一致